### PR TITLE
Use a nullable array implementation internally

### DIFF
--- a/dune
+++ b/dune
@@ -1,6 +1,7 @@
 (library
  (public_name vector)
- (modules vector))
+ (modules vector)
+ (libraries nullable-array))
 
 (test
  (name test)

--- a/test.ml
+++ b/test.ml
@@ -3,7 +3,7 @@ open Format
 open Vector
 
 let () =
-  let v = make 0 ~dummy:42 in
+  let v = create () in
   push v 17;
   push v 2;
   assert (length v = 2);
@@ -13,7 +13,7 @@ let () =
 
 let () =
   let n = 20 in
-  let v = make 1 ~dummy:0 in
+  let v = make 1 0 in
   push v 1;
   for i = 2 to n do push v (get v (i-2) + get v (i-1)) done;
   assert (length v = n+1);
@@ -23,7 +23,7 @@ let () =
 (* stack *)
 
 let () =
-  let s = create ~dummy:42 in
+  let s = create () in
   push s 1;
   assert (top s = 1);
   push s 2;
@@ -40,8 +40,8 @@ let () =
   ()
 
 let () =
-  let v = make 12 ~dummy:() in
-  for i = 0 to 1000 do resize v i done;
-  for i = 1000 downto 0 do resize v i done;
-  for _ = 1 to 1000 do resize v (Random.int 10_000) done;
+  let v = make 12 () in
+  for i = 0 to 1000 do resize v i () done;
+  for i = 1000 downto 0 do shrink v i done;
+  for _ = 1 to 1000 do resize v (Random.int 10_000) () done;
   ()

--- a/vector.ml
+++ b/vector.ml
@@ -13,60 +13,86 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Narray = Nullable_array
+
 type 'a t = {
-          dummy: 'a;
   mutable size:  int;
-  mutable data:  'a array; (* 0 <= size <= Array.length data *)
+  mutable data:  'a Narray.t; (* 0 <= size <= Narray.length data *)
 }
 
-let make n ~dummy =
-  if n < 0 || n > Sys.max_array_length then invalid_arg "Vector.make";
-  { dummy = dummy; size = n; data = Array.make n dummy; }
+let make n v =
+  if n < 0 || n > Narray.max_length then invalid_arg "Vector.make";
+  { size = n; data = Narray.make_some n v; }
 
-let create ~dummy =
-  make 0 ~dummy
+let create () =
+  { size = 0; data = Narray.empty_array }
 
-let init n ~dummy f =
-  if n < 0 || n > Sys.max_array_length then invalid_arg "Vector.init";
-  { dummy = dummy; size = n; data = Array.init n f; }
+let init n f =
+  if n < 0 || n > Narray.max_length then invalid_arg "Vector.init";
+  { size = n; data = Narray.init_some n f; }
 
 let length a =
   a.size
 
 let get a i =
   if i < 0 || i >= a.size then invalid_arg "Vector.get";
-  Array.unsafe_get a.data i
+  Narray.unsafe_get_some a.data i
 
 let set a i v =
   if i < 0 || i >= a.size then invalid_arg "Vector.set";
-  Array.unsafe_set a.data i v
+  Narray.unsafe_set_some a.data i v
 
 let unsafe_get a i =
-  Array.unsafe_get a.data i
+  Narray.unsafe_get_some a.data i
 
 let unsafe_set a i v =
-  Array.unsafe_set a.data i v
+  Narray.unsafe_set_some a.data i v
 
-let resize a s =
-  if s < 0 then invalid_arg "Vector.resize";
-  let n = Array.length a.data in
-  if s <= a.size then
-    (* shrink *)
-    if 4 * s < n then (* reallocate into a smaller array *)
-      a.data <- Array.sub a.data 0 s
-    else
-      Array.fill a.data s (a.size - s) a.dummy
+(* shrink that assumes [0 <= s < a.size] *)
+let unsafe_shrink a s =
+  let n = Narray.length a.data in
+  if 4 * s < n then (* reallocate into a smaller array *)
+    a.data <- Narray.sub a.data 0 s
   else begin
-    (* grow *)
-    if s > n then begin (* reallocate into a larger array *)
-      if s > Sys.max_array_length then invalid_arg "Vector.resize: cannot grow";
-      let n' = min (max (2 * n) s) Sys.max_array_length in
-      let a' = Array.make n' a.dummy in
-      Array.blit a.data 0 a' 0 a.size;
-      a.data <- a'
-    end
+    for i = s to a.size - s do
+      Narray.clear a.data i
+    done
   end;
   a.size <- s
+
+let shrink a s =
+  if s < 0 then invalid_arg "Vector.shrink";
+  if s < a.size then unsafe_shrink a s
+
+(* expansion that creates an uninitialised suffix *)
+let unsafe_expand a s =
+  if s > a.size then begin
+    let n = Narray.length a.data in
+    if s > n then begin
+      let n' = min (max (2 * n) s) Narray.max_length in
+      let a' = Narray.make n' in
+      Narray.blit a.data 0 a' 0 a.size;
+      a.data <- a'
+    end;
+    a.size <- s
+  end
+
+let resize a s v =
+  if s < 0 then invalid_arg "Vector.resize";
+  if s <= a.size then
+    unsafe_shrink a s
+  else begin
+    let n = Narray.length a.data in
+    (* grow *)
+    if s > n then begin (* reallocate into a larger array *)
+      if s > Narray.max_length then invalid_arg "Vector.resize: cannot grow";
+      let n' = min (max (2 * n) s) Narray.max_length in
+      let a' = Narray.make_some n' v in
+      Narray.blit a.data 0 a' 0 a.size;
+      a.data <- a'
+    end;
+    a.size <- s
+  end
 
 (** stack interface *)
 
@@ -74,25 +100,25 @@ let is_empty a =
   length a = 0
 
 let clear a =
-  resize a 0
+  shrink a 0
 
 let push a v =
   let n = a.size in
-  resize a (n+1);
-  Array.unsafe_set a.data n v
+  unsafe_expand a (n+1);
+  Narray.unsafe_set_some a.data n v
 
 exception Empty
 
 let top a =
   let n = length a in
   if n = 0 then raise Empty;
-  Array.unsafe_get a.data (n - 1)
+  Narray.unsafe_get_some a.data (n - 1)
 
 let pop a =
   let n = length a - 1 in
   if n < 0 then raise Empty;
-  let r = Array.unsafe_get a.data n in
-  resize a n;
+  let r = Narray.unsafe_get_some a.data n in
+  shrink a n;
   r
 
 (** array interface *)
@@ -100,17 +126,16 @@ let pop a =
 let append a1 a2 =
   let n1 = length a1 in
   let n2 = length a2 in
-  resize a1 (n1 + n2);
+  unsafe_expand a1 (n1 + n2);
   for i = 0 to n2 - 1 do unsafe_set a1 (n1 + i) (unsafe_get a2 i) done
 
 let copy a =
-  { dummy = a.dummy;
-    size = a.size;
-    data = Array.copy a.data; }
+  { size = a.size;
+    data = Narray.copy a.data; }
 
 let sub a ofs len =
   if len < 0 || ofs > length a - len then invalid_arg "Vector.sub";
-  { dummy = a.dummy; size = len; data = Array.sub a.data ofs len }
+  { size = len; data = Narray.sub a.data ofs len }
 
 let fill a ofs len v =
   if ofs < 0 || len < 0 || ofs > length a - len then invalid_arg "Vector.fill";
@@ -133,28 +158,28 @@ let iter f a =
   for i = 0 to length a - 1 do f (unsafe_get a i) done
 
 let map f a =
-  { dummy = f a.dummy; size = a.size; data = Array.map f a.data }
+  { size = a.size; data = Narray.map_some f a.data }
 
 let iteri f a =
   for i = 0 to length a - 1 do f i (unsafe_get a i) done
 
 let mapi f a =
-  { dummy = f 0 a.dummy; size = a.size; data = Array.mapi f a.data }
+  { size = a.size; data = Narray.mapi_some f a.data }
 
 let to_list a =
   let rec tolist i res =
     if i < 0 then res else tolist (i - 1) (unsafe_get a i :: res) in
   tolist (length a - 1) []
 
-let of_list ~dummy l =
-  let a = Array.of_list l in
-  { dummy = dummy; size = Array.length a; data = a }
+let of_list l =
+  let a = Narray.of_list l in
+  { size = Narray.length a; data = a }
 
 let to_array a =
-  Array.sub a.data 0 a.size
+  Array.init a.size (fun i -> Narray.unsafe_get_some a.data i)
 
-let of_array ~dummy a =
-  { dummy = dummy; size = Array.length a; data = Array.copy a }
+let of_array a =
+  { size = Array.length a; data = Narray.of_array a }
 
 let fold_left f x a =
   let r = ref x in

--- a/vector.mli
+++ b/vector.mli
@@ -77,7 +77,7 @@ val resize: 'a t -> int -> unit
 
 (** {2 Stack interface}
 
-    Contrary to standard library's {Stack}, module {Vector} uses less space
+    Contrary to standard library's {!Stack}, module [Vector] uses less space
     (between N and 2N words, instead of 3N) and has better data locality. *)
 
 val push: 'a t -> 'a -> unit

--- a/vector.opam
+++ b/vector.opam
@@ -10,6 +10,7 @@ bug-reports: "https://github.com/backtracking/vector/issues"
 depends: [
   "ocaml"
   "dune" {>= "2.0.0"}
+  "nullable-array"
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/vector.opam
+++ b/vector.opam
@@ -18,3 +18,8 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/backtracking/vector.git"
+
+# TODO: not to be merged. Remove once https://github.com/chambart/ocaml-nullable-array/pull/1 is released
+pin-depends: [
+  [ "nullable-array.dev" "git+https://github.com/craigfe/ocaml-nullable-array#70f8ebe331895daea7519031ddc87ddc52175756" ]
+]


### PR DESCRIPTION
This PR contains the patch described in https://github.com/backtracking/vector/issues/1. It's not mergeable yet as it relies on extensions to `nullable-array` (PRed [here](https://github.com/chambart/ocaml-nullable-array/pull/1)), but I thought I'd create the PR now in case there are any initial comments (which will perhaps create new requirements for my other patch).

The changes are as follows:

- remove all `~dummy` arguments;
- change `resize` to require an initialisation element for the new suffix that it may create;
- add `shrink`, a variant of `resize` that can only reduce the size of the vector and so doesn't need an initialisation element;
- add a dependency on the `nullable-array` library.

I haven't added any new test cases, but I'm very happy to do so. The existing ones are passing in the CI system on my own fork ([here](https://ci.ocamllabs.io/github/CraigFe/vector/commit/603d86bdd5484de6e8925051ec0c581d451b10e0)), which has decent platform coverage.