### PR TITLE
Provide `Vector.swap_contents`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+# Unreleased
+  - added `Vector.swap_contents`
 
 # 1.0.0
   - first opam package

--- a/test.ml
+++ b/test.ml
@@ -45,3 +45,13 @@ let () =
   for i = 1000 downto 0 do resize v i done;
   for _ = 1 to 1000 do resize v (Random.int 10_000) done;
   ()
+
+(* swap_contents *)
+
+let () =
+  let odd = [ 1; 3; 5 ] and even = [ 2; 4 ] in
+  let init_odd = of_list ~dummy:0 odd
+  and init_even = of_list ~dummy:0 even in
+  swap_contents init_odd init_even;
+  assert (to_list init_odd = even);
+  assert (to_list init_even = odd)

--- a/vector.ml
+++ b/vector.ml
@@ -14,7 +14,7 @@
 (**************************************************************************)
 
 type 'a t = {
-          dummy: 'a;
+  mutable dummy: 'a;
   mutable size:  int;
   mutable data:  'a array; (* 0 <= size <= Array.length data *)
 }
@@ -128,6 +128,17 @@ let blit a1 ofs1 a2 ofs2 len =
     for i = 0 to len - 1 do
       unsafe_set a2 (ofs2 + i) (unsafe_get a1 (ofs1 + i))
     done
+
+let swap_contents a b =
+  let tmp_dummy = a.dummy
+  and tmp_size = a.size
+  and tmp_data = a.data in
+  a.dummy <- b.dummy;
+  a.size <- b.size;
+  a.data <- b.data;
+  b.dummy <- tmp_dummy;
+  b.size <- tmp_size;
+  b.data <- tmp_data
 
 let iter f a =
   for i = 0 to length a - 1 do f (unsafe_get a i) done

--- a/vector.mli
+++ b/vector.mli
@@ -158,6 +158,10 @@ val blit : 'a t -> int -> 'a t -> int -> int -> unit
    designate a valid subvector of [v1], or if [o2] and [len] do not
    designate a valid subvector of [v2]. *)
 
+val swap_contents : 'a t -> 'a t -> unit
+(** [Vector.swap_contents v1 v2] exchanges the contents of vectors [v1]
+    and [v2] in constant time. *)
+
 val to_list : 'a t -> 'a list
 (** [Vector.to_list a] returns the list of all the elements of [a]. *)
 


### PR DESCRIPTION
Adds an operation of the following type:

```ocaml
val swap_contents : 'a t -> 'a t -> unit
```

I ran into the need for this operation when using a vector to store work items that are consumed in batches.

Note on the naming: I chose `swap_contents` to leave room for a potential `swap : 'a t -> int -> int -> unit` (such as provided by the [Rust stdlib](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.swap), or Haskell's [`Data.Vector.Mutable`](https://hackage.haskell.org/package/vector-0.12.3.0/docs/Data-Vector-Mutable.html)). The C++ stdlib calls it `std::vector::swap`, but they have access to `std::swap` directly for the other semantics. Other suggestions welcome.